### PR TITLE
`no_std` support for Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ bevy_math = { version = "0.15", default-features = false, features = [
 # Random number generation
 rand = "0.8"
 rand_chacha = "0.3"
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ keywords = ["gamedev", "physics", "simulation", "math", "mass", "bevy"]
 categories = ["game-development", "science", "mathematics", "simulation"]
 
 [features]
-default = ["2d", "3d", "bevy_reflect"]
+default = ["std", "2d", "3d", "bevy_reflect"]
 
 # Enable 2D functionality.
-2d = []
+2d = ["bevy_math/alloc"]
 
 # Enable 3D functionality.
-3d = []
+3d = ["bevy_math/alloc"]
 
 # Enable reflection using `bevy_reflect`.
 bevy_reflect = ["dep:bevy_reflect", "bevy_math/bevy_reflect"]
@@ -33,12 +33,12 @@ approx = ["dep:approx", "bevy_math/approx"]
 # across platforms at the cost of losing hardware-level optimization using intrinsics.
 libm = ["bevy_math/libm"]
 
+std = ["bevy_math/std"]
+
 [dependencies]
 # Math
 approx = { version = "0.5", optional = true }
-bevy_math = { version = "0.16.0-rc.1", default-features = false, features = [
-    "std",
-] }
+bevy_math = { version = "0.16.0-rc.1", default-features = false }
 
 # Serialization
 bevy_reflect = { version = "0.16.0-rc.1", default-features = false, optional = true }
@@ -51,9 +51,9 @@ bevy_heavy = { path = ".", features = ["approx"] }
 # Math
 approx = { version = "0.5", default-features = false }
 bevy_math = { version = "0.16.0-rc.1", default-features = false, features = [
-    "std",
-    "approx",
-    "rand",
+  "std",
+  "approx",
+  "rand",
 ] }
 
 # Random number generation

--- a/src/dim2/impls.rs
+++ b/src/dim2/impls.rs
@@ -180,7 +180,7 @@ impl ComputeMassProperties2d for RegularPolygon {
 
     #[inline]
     fn unit_angular_inertia(&self) -> f32 {
-        let half_external_angle = std::f32::consts::PI / self.sides as f32;
+        let half_external_angle = core::f32::consts::PI / self.sides as f32;
         self.circumradius().squared() / 6.0 * (1.0 + 2.0 * ops::cos(half_external_angle).squared())
     }
 
@@ -193,7 +193,7 @@ impl ComputeMassProperties2d for RegularPolygon {
 impl ComputeMassProperties2d for Capsule2d {
     #[inline]
     fn mass(&self, density: f32) -> f32 {
-        let area = self.radius * (std::f32::consts::PI * self.radius + 4.0 * self.half_length);
+        let area = self.radius * (core::f32::consts::PI * self.radius + 4.0 * self.half_length);
         area * density
     }
 

--- a/src/dim2/impls.rs
+++ b/src/dim2/impls.rs
@@ -511,10 +511,13 @@ impl<const N: usize> ComputeMassProperties2d for Polyline2d<N> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use alloc::vec::Vec;
+
     use approx::assert_relative_eq;
     use bevy_math::ShapeSample;
     use rand::SeedableRng;
+
+    use super::*;
 
     macro_rules! test_shape {
         ($test_name:tt, $shape:expr) => {

--- a/src/dim2/mod.rs
+++ b/src/dim2/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use bevy_math::{DVec2, Isometry2d, Vec2};
 #[cfg(all(feature = "bevy_reflect", feature = "serialize"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -188,7 +190,7 @@ impl MassProperties2d {
     }
 }
 
-impl std::ops::Add for MassProperties2d {
+impl core::ops::Add for MassProperties2d {
     type Output = Self;
 
     #[inline]
@@ -220,14 +222,14 @@ impl std::ops::Add for MassProperties2d {
     }
 }
 
-impl std::ops::AddAssign for MassProperties2d {
+impl core::ops::AddAssign for MassProperties2d {
     #[inline]
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
-impl std::ops::Sub for MassProperties2d {
+impl core::ops::Sub for MassProperties2d {
     type Output = Self;
 
     #[inline]
@@ -266,14 +268,14 @@ impl std::ops::Sub for MassProperties2d {
     }
 }
 
-impl std::ops::SubAssign for MassProperties2d {
+impl core::ops::SubAssign for MassProperties2d {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
-impl std::iter::Sum for MassProperties2d {
+impl core::iter::Sum for MassProperties2d {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         let mut total_mass = 0.0;

--- a/src/dim3/angular_inertia.rs
+++ b/src/dim3/angular_inertia.rs
@@ -1,4 +1,4 @@
-use std::ops::*;
+use core::ops::*;
 
 use crate::MatExt;
 use bevy_math::{Mat3, Quat, Vec3};
@@ -236,11 +236,11 @@ impl AngularInertiaTensor {
         let mut eigen = SymmetricEigen3::new(self.0).reverse();
 
         if eigen.eigenvectors.determinant() < 0.0 {
-            std::mem::swap(
+            core::mem::swap(
                 &mut eigen.eigenvectors.y_axis,
                 &mut eigen.eigenvectors.z_axis,
             );
-            std::mem::swap(&mut eigen.eigenvalues.y, &mut eigen.eigenvalues.z);
+            core::mem::swap(&mut eigen.eigenvalues.y, &mut eigen.eigenvalues.z);
         }
 
         let mut local_inertial_frame = Quat::from_mat3(&eigen.eigenvectors).normalize();

--- a/src/dim3/eigen3.rs
+++ b/src/dim3/eigen3.rs
@@ -37,12 +37,12 @@ impl SymmetricEigen3 {
             // ordering the eigenvectors accordingly, and return early.
             let mut eigenvectors = Mat3::IDENTITY;
             if eigenvalues[0] > eigenvalues[1] {
-                std::mem::swap(&mut eigenvalues.x, &mut eigenvalues.y);
-                std::mem::swap(&mut eigenvectors.x_axis, &mut eigenvectors.y_axis);
+                core::mem::swap(&mut eigenvalues.x, &mut eigenvalues.y);
+                core::mem::swap(&mut eigenvectors.x_axis, &mut eigenvectors.y_axis);
             }
             if eigenvalues[1] > eigenvalues[2] {
-                std::mem::swap(&mut eigenvalues.y, &mut eigenvalues.z);
-                std::mem::swap(&mut eigenvectors.y_axis, &mut eigenvectors.z_axis);
+                core::mem::swap(&mut eigenvalues.y, &mut eigenvalues.z);
+                core::mem::swap(&mut eigenvectors.y_axis, &mut eigenvectors.z_axis);
             }
             return Self {
                 eigenvalues,
@@ -93,14 +93,14 @@ impl SymmetricEigen3 {
             + (mat.y_axis.y - q).squared()
             + (mat.z_axis.z - q).squared()
             + 2.0 * p1;
-        let p = (p2 / 6.0).sqrt();
+        let p = ops::sqrt(p2 / 6.0);
         let mat_b = 1.0 / p * (mat - q * Mat3::IDENTITY);
         let r = mat_b.determinant() / 2.0;
 
         // r should be in the [-1, 1] range for a symmetric matrix,
         // but computation error can leave it slightly outside this range.
         let phi = if r <= -1.0 {
-            std::f32::consts::FRAC_PI_3
+            core::f32::consts::FRAC_PI_3
         } else if r >= 1.0 {
             0.0
         } else {
@@ -109,7 +109,7 @@ impl SymmetricEigen3 {
 
         // The eigenvalues satisfy eigen3 <= eigen2 <= eigen1
         let eigen1 = q + 2.0 * p * ops::cos(phi);
-        let eigen3 = q + 2.0 * p * ops::cos(phi + 2.0 * std::f32::consts::FRAC_PI_3);
+        let eigen3 = q + 2.0 * p * ops::cos(phi + 2.0 * core::f32::consts::FRAC_PI_3);
         let eigen2 = 3.0 * q - eigen1 - eigen3; // trace(mat) = eigen1 + eigen2 + eigen3
         (Vec3::new(eigen3, eigen2, eigen1), false)
     }
@@ -143,11 +143,11 @@ impl SymmetricEigen3 {
             i_max = 2;
         }
         if i_max == 0 {
-            c0xc1 / d0.sqrt()
+            c0xc1 / ops::sqrt(d0)
         } else if i_max == 1 {
-            c0xc2 / d1.sqrt()
+            c0xc2 / ops::sqrt(d1)
         } else {
-            c1xc2 / d2.sqrt()
+            c1xc2 / ops::sqrt(d2)
         }
     }
 
@@ -184,13 +184,13 @@ impl SymmetricEigen3 {
                     // m00 is the largest component of the row.
                     // Factor it out for normalization and discard to avoid underflow or overflow.
                     m01 /= m00;
-                    m00 = 1.0 / (1.0 + m01 * m01).sqrt();
+                    m00 = 1.0 / ops::sqrt(1.0 + m01 * m01);
                     m01 *= m00;
                 } else {
                     // m01 is the largest component of the row.
                     // Factor it out for normalization and discard to avoid underflow or overflow.
                     m00 /= m01;
-                    m01 = 1.0 / (1.0 + m00 * m00).sqrt();
+                    m01 = 1.0 / ops::sqrt(1.0 + m00 * m00);
                     m00 *= m01;
                 }
                 return m01 * u - m00 * v;
@@ -202,13 +202,13 @@ impl SymmetricEigen3 {
                     // m11 is the largest component of the row.
                     // Factor it out for normalization and discard to avoid underflow or overflow.
                     m01 /= m11;
-                    m11 = 1.0 / (1.0 + m01 * m01).sqrt();
+                    m11 = 1.0 / ops::sqrt(1.0 + m01 * m01);
                     m01 *= m11;
                 } else {
                     // m01 is the largest component of the row.
                     // Factor it out for normalization and discard to avoid underflow or overflow.
                     m11 /= m01;
-                    m01 = 1.0 / (1.0 + m11 * m11).sqrt();
+                    m01 = 1.0 / ops::sqrt(1.0 + m11 * m11);
                     m11 *= m01;
                 }
                 return m11 * u - m01 * v;

--- a/src/dim3/impls.rs
+++ b/src/dim3/impls.rs
@@ -206,7 +206,7 @@ impl ComputeMassProperties3d for ConicalFrustum {
         } else {
             // https://mathworld.wolfram.com/ConicalFrustum.html
             let radii_squared = self.radius_top.squared() + self.radius_bottom.squared();
-            let volume = std::f32::consts::FRAC_PI_3
+            let volume = core::f32::consts::FRAC_PI_3
                 * self.height
                 * (radii_squared + self.radius_top * self.radius_bottom);
             volume * density

--- a/src/dim3/impls.rs
+++ b/src/dim3/impls.rs
@@ -670,13 +670,16 @@ impl<const N: usize> ComputeMassProperties3d for Polyline3d<N> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use alloc::vec::Vec;
+
     use approx::assert_relative_eq;
     use bevy_math::{
         bounding::{Bounded3d, BoundingVolume},
         Isometry3d, ShapeSample, Vec3Swizzles,
     };
     use rand::SeedableRng;
+
+    use super::*;
 
     macro_rules! test_shape {
         ($test_name:tt, $shape:expr, $point_generator:expr) => {

--- a/src/dim3/mod.rs
+++ b/src/dim3/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use bevy_math::{DVec3, Isometry3d, Mat3, Quat, Vec3};
 #[cfg(all(feature = "bevy_reflect", feature = "serialize"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -306,7 +308,7 @@ impl MassProperties3d {
     }
 }
 
-impl std::ops::Add for MassProperties3d {
+impl core::ops::Add for MassProperties3d {
     type Output = Self;
 
     #[inline]
@@ -334,14 +336,14 @@ impl std::ops::Add for MassProperties3d {
     }
 }
 
-impl std::ops::AddAssign for MassProperties3d {
+impl core::ops::AddAssign for MassProperties3d {
     #[inline]
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
-impl std::ops::Sub for MassProperties3d {
+impl core::ops::Sub for MassProperties3d {
     type Output = Self;
 
     #[inline]
@@ -376,14 +378,14 @@ impl std::ops::Sub for MassProperties3d {
     }
 }
 
-impl std::ops::SubAssign for MassProperties3d {
+impl core::ops::SubAssign for MassProperties3d {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
-impl std::iter::Sum for MassProperties3d {
+impl core::iter::Sum for MassProperties3d {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         let mut total_mass = 0.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,9 @@
 //! [centroid]: https://en.wikipedia.org/wiki/Centroid
 
 #![warn(missing_docs)]
+#![no_std]
+
+extern crate alloc;
 
 #[cfg(feature = "2d")]
 mod dim2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@
 #![warn(missing_docs)]
 #![no_std]
 
+#[cfg(any(feature = "2d", feature = "3d"))]
 extern crate alloc;
 
 #[cfg(feature = "2d")]


### PR DESCRIPTION
# Objective

- Add `no_std` support ready for Bevy 0.16

## Solution

- Added `x_instead_of_y` lints to reduce reliance on `std` and `alloc`
- Added `#![no_std]`
- Tested against current `bevy` main branch to confirm `no_std` compatibility on `wasm32v1-none` once 0.16 releases

---

## Notes

- This crate was already very close to being `no_std`, just needed its imports renamed.
- Fails now as it relies on features and changes that are present in 0.16