### PR TITLE
Migrate to Bevy 0.16.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,12 @@ libm = ["bevy_math/libm"]
 [dependencies]
 # Math
 approx = { version = "0.5", optional = true }
-bevy_math = { version = "0.15", default-features = false }
+bevy_math = { version = "0.16.0-rc.1", default-features = false, features = [
+    "std",
+] }
 
 # Serialization
-bevy_reflect = { version = "0.15", default-features = false, optional = true }
+bevy_reflect = { version = "0.16.0-rc.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -47,12 +49,13 @@ serde = { version = "1.0", default-features = false, optional = true }
 bevy_heavy = { path = ".", features = ["approx"] }
 
 # Math
-approx = "0.5"
-bevy_math = { version = "0.15", default-features = false, features = [
+approx = { version = "0.5", default-features = false }
+bevy_math = { version = "0.16.0-rc.1", default-features = false, features = [
+    "std",
     "approx",
     "rand",
 ] }
 
 # Random number generation
-rand = "0.8"
-rand_chacha = "0.3"
+rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ or `ComputeMassProperties3d` for them.
 
 | `bevy_math` | `bevy_heavy` |
 | ----------- | ------------ |
+| 0.16 RC     | main         |
 | 0.15        | 0.1          |
 
 ## License


### PR DESCRIPTION
# Objective

The first release candidate for Bevy 0.16 has been released! We should migrate our main branch to it.

Bevy 0.16 also adds `no_std` support, but I am not handling that properly in this PR yet. `no_std` support will be added by #1.

Adding mass property support for new shapes like `ConvexPolygon` will also be handled in follow-ups.

## Solution

Migrate to Bevy 0.16.0-rc.1. This is purely a version bump in this case.

I also disabled default features for a few more crates.