### PR TITLE
Check `no_std` compatibility in CI and fix remaining use of `std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,61 @@
 name: CI
 
 on:
-    push:
-        branches:
-            - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
-    CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: always
 
 jobs:
-    check:
-        name: Check
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
-            - name: Run cargo check
-              run: cargo check
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo check
+        run: cargo check
 
-    test:
-        name: Test Suite
-        strategy:
-            matrix:
-                os: [windows-latest, ubuntu-latest, macos-latest]
-        runs-on: ${{ matrix.os }}
-        timeout-minutes: 60
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
-            - name: Run cargo test
-              run: cargo test --all-features
+  check-compiles-no-std:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - "x86_64-unknown-none"
+          - "wasm32v1-none"
+          - "thumbv6m-none-eabi"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Run cargo check
+        run: cargo check --no-default-features --features libm,critical-section --target ${{ matrix.target }}
 
-    lints:
-        name: Lints
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
-            - name: Run cargo fmt
-              run: cargo fmt --all -- --check
-            - name: Run cargo clippy
-              run: cargo clippy -- -D warnings
+  test:
+    name: Test Suite
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo test
+        run: cargo test --all-features
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Run cargo check
-        run: cargo check --no-default-features --features libm,critical-section --target ${{ matrix.target }}
+        run: cargo check --no-default-features --features libm --target ${{ matrix.target }}
 
   test:
     name: Test Suite

--- a/clippy.toml
+++ b/clippy.toml
@@ -26,4 +26,13 @@ disallowed-methods = [
     { path = "f32::asinh", reason = "use ops::asinh instead for libm determinism" },
     { path = "f32::acosh", reason = "use ops::acosh instead for libm determinism" },
     { path = "f32::atanh", reason = "use ops::atanh instead for libm determinism" },
+    # These methods have defined precision, but are only available from the standard library,
+    # not in core. Using these substitutes allows for no_std compatibility.
+    { path = "f32::rem_euclid", reason = "use ops::rem_euclid instead for no_std compatibility" },
+    { path = "f32::abs", reason = "use ops::abs instead for no_std compatibility" },
+    { path = "f32::sqrt", reason = "use ops::sqrt instead for no_std compatibility" },
+    { path = "f32::copysign", reason = "use ops::copysign instead for no_std compatibility" },
+    { path = "f32::round", reason = "use ops::round instead for no_std compatibility" },
+    { path = "f32::floor", reason = "use ops::floor instead for no_std compatibility" },
+    { path = "f32::fract", reason = "use ops::fract instead for no_std compatibility" },
 ]

--- a/src/dim3/eigen3.rs
+++ b/src/dim3/eigen3.rs
@@ -175,7 +175,7 @@ impl SymmetricEigen3 {
         let mut m00 = u.dot(au) - eigenvalue2;
         let mut m01 = u.dot(av);
         let mut m11 = v.dot(av) - eigenvalue2;
-        let (abs_m00, abs_m01, abs_m11) = (m00.abs(), m01.abs(), m11.abs());
+        let (abs_m00, abs_m01, abs_m11) = (ops::abs(m00), ops::abs(m01), ops::abs(m11));
 
         if abs_m00 >= abs_m11 {
             let max_abs_component = abs_m00.max(abs_m01);

--- a/src/dim3/impls.rs
+++ b/src/dim3/impls.rs
@@ -1,5 +1,6 @@
 use super::{AngularInertiaTensor, ComputeMassProperties3d, MassProperties3d};
 use bevy_math::{
+    ops,
     prelude::Tetrahedron,
     primitives::{
         BoxedPolyline3d, Capsule3d, Cone, ConicalFrustum, Cuboid, Cylinder, Line3d, Measured3d,
@@ -236,7 +237,7 @@ impl ComputeMassProperties3d for ConicalFrustum {
 
             // Create the large and small cone.
             let cone_height =
-                max_radius * (self.height / (self.radius_top - self.radius_bottom).abs());
+                max_radius * (self.height / ops::abs(self.radius_top - self.radius_bottom));
             let large_cone = Cone {
                 radius: max_radius,
                 height: cone_height,
@@ -330,7 +331,7 @@ impl ComputeMassProperties3d for ConicalFrustum {
 
             // Create the large and small cone.
             let cone_height =
-                max_radius * (self.height / (self.radius_top - self.radius_bottom).abs());
+                max_radius * (self.height / ops::abs(self.radius_top - self.radius_bottom));
             let large_cone = Cone {
                 radius: max_radius,
                 height: cone_height,


### PR DESCRIPTION
# Objective

It can be easy to accidentally break `no_std` compatibility. We should check it in CI!

We're also missing some `f32` method lints in `clippy.toml`, and are still actually using `std::f32::round` in one place.

## Solution

Add `no_std` checks to CI, and add the remaining `f32` method lints to `clippy.toml`.

The check is based on [`no_std` library example](https://github.com/bevyengine/bevy/tree/0244a841b78ea9a995880fea6733da21a6c0fea2/examples/no_std/library).